### PR TITLE
Fix extra parens

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -502,7 +502,7 @@ if (isSessionValid) {
 
 ```js
 // Execute a regex
-var matches = item.match(/ID_([^\n]+)=([^\n]+)/));
+var matches = item.match(/ID_([^\n]+)=([^\n]+)/);
 
 // Usage: loadUser(5, function() { ... })
 function loadUser(id, cb) {


### PR DESCRIPTION
I'm getting a parse error because of the extra parens? (After running through some of the readme through JSCS/esprima).

```
var matches = item.match(/ID_([^\n]+)=([^\n]+)/));
var matches = item.match(/ID_([^\n]+)=([^\n]+)/);
```