### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,6 @@
     "semi": [2, "always"],
     "space-after-keywords": [2, "always"],
     "space-in-brackets": [2, "never"],
-    "space-unary-word-ops": 2
+    "space-unary-ops": 2
   }
 }


### PR DESCRIPTION
The rule "space-unary-word-ops" is not found on my machine.
Replaced by "space-unary-ops" instead.