### PR TITLE
Add module.exports for ESLint and JSHint rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var readFile = require('fs').readFileSync;
+var pathJoin = require('path').join;
+
+module.exports = {
+  eslintrc: loadJson('.eslintrc'),
+  jshintrc: loadJson('.jshintrc')
+};
+
+function loadJson(configFile) {
+  var data = readFile(pathJoin(__dirname, configFile), 'utf-8');
+  return JSON.parse(data);
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "jshint"
   ],
   "license": "CC-BY-SA-3.0",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/felixge/node-style-guide.git"


### PR DESCRIPTION
This will make it easier to consume the configs using something like the following:

```js
var config = require('node-style-guide');

console.log(config.eslintrc);

/** OUTPUT:
{ env: { node: true },
  rules:
   { 'array-bracket-spacing': [ 2, 'never' ],
     'block-scoped-var': 2,
     'brace-style': [ 2, '1tbs' ],
     camelcase: 1,
     'computed-property-spacing': [ 2, 'never' ],
     curly: 2,
     'eol-last': 2,
     eqeqeq: [ 2, 'smart' ],
     'max-depth': [ 1, 3 ],
     'max-len': [ 1, 80 ],
     'max-statements': [ 1, 15 ],
     'new-cap': 1,
     'no-extend-native': 2,
     'no-mixed-spaces-and-tabs': 2,
     'no-trailing-spaces': 2,
     'no-unused-vars': 1,
     'no-use-before-define': [ 2, 'nofunc' ],
     'object-curly-spacing': [ 2, 'never' ],
     quotes: [ 2, 'single', 'avoid-escape' ],
     semi: [ 2, 'always' ],
     'space-after-keywords': [ 2, 'always' ],
     'space-unary-ops': 2 } }
*/
```

... Which also means I'll be able to update the **eslint-config-node-style-guide** module to do something as simple as:
```js
'use strict';
module.exports = require('node-style-guide').eslintrc;
```