### PR TITLE
[breaking] Change "space-after-keywords" ESLint rule to "keyword-spacing"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
     "object-curly-spacing": [2, "never"],
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "always"],
-    "space-after-keywords": [2, "always"],
+    "keyword-spacing": [2, {"before": true, "after": true}],
     "space-unary-ops": 2
   }
 }


### PR DESCRIPTION
Since this is a breaking eslint@2 change, we should bump the package.json version before publishing a new version to npm.

Fixes #84