### PR TITLE
Make heading levels consistent

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -167,7 +167,7 @@ while (keys.length) {
 
 [crockfordconvention]: http://javascript.crockford.com/code.html
 
-### Naming Conventions
+## Naming Conventions
 
 ### Use lowerCamelCase for variables, properties and function names
 
@@ -205,7 +205,7 @@ function bank_Account() {
 }
 ```
 
-## Use UPPERCASE for Constants
+### Use UPPERCASE for Constants
 
 Constants should be declared as regular variables or static class properties,
 using all uppercase letters.
@@ -446,7 +446,7 @@ User
   .exec(function(err, user) {
     return true;
   });
-````
+```
 
 *Wrong:*
 
@@ -473,7 +473,7 @@ User.findOne({ name: 'foo' }).populate('bar')
   .exec(function(err, user) {
     return true;
   });
-````
+```
 
 ## Comments
 


### PR DESCRIPTION
Changed heading levels for the 'Naming Conventions' section.
Also removed extra back-ticks in the closing of 'Method chaining' example code blocks.